### PR TITLE
Added gitignore for CMake artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+build
+.cache
+Debug
+Release


### PR DESCRIPTION
This prevents git from caring when we create CMake assets in our cloned examples folder. Much cleaner in git status and any tools that play well with git. 