### PR TITLE
evkmimxrt1064: driver_examples: csi: rgb565: Resubmit 1st framebuffer

### DIFF
--- a/evkmimxrt1064/driver_examples/csi/rgb565/csi_rgb565.c
+++ b/evkmimxrt1064/driver_examples/csi/rgb565/csi_rgb565.c
@@ -18,7 +18,7 @@
  ******************************************************************************/
 
 
-#define APP_FRAME_BUFFER_COUNT 4
+#define APP_FRAME_BUFFER_COUNT 2
 /* Pixel format RGB565, bytesPerPixel is 2. */
 #define APP_BPP 2
 

--- a/evkmimxrt1064/driver_examples/csi/rgb565/csi_rgb565.c
+++ b/evkmimxrt1064/driver_examples/csi/rgb565/csi_rgb565.c
@@ -175,6 +175,7 @@ static void APP_CSI_RGB565(void)
     }
 
     s_newFrameShown = true;
+    CAMERA_RECEIVER_SubmitEmptyBuffer(&cameraReceiver, cameraReceivedFrameAddr);
 
     g_dc.ops->enableLayer(&g_dc, 0);
 


### PR DESCRIPTION
The application hangs forever if we want to use only two buffers:

  #define APP_FRAME_BUFFER_COUNT 2

This is because the 1st framebuffer has not been resubmitted to the queue, so the camera does not have enough buffer to move on.